### PR TITLE
Use `AUTH_PROFILE_MODULE` if set.

### DIFF
--- a/admin_sso/models.py
+++ b/admin_sso/models.py
@@ -8,6 +8,11 @@ except ImportError:
 
 from admin_sso import settings
 
+try:
+    User = settings.AUTH_PROFILE_MODULE
+except AttributeError:
+    from django.contrib.auth.models import User
+
 
 class Assignment(models.Model):
     username_mode = models.IntegerField(choices=settings.ASSIGNMENT_CHOICES)
@@ -15,7 +20,7 @@ class Assignment(models.Model):
     domain = models.CharField(max_length=255)
     copy = models.BooleanField(default=False)
     weight = models.PositiveIntegerField(default=0)
-    user = models.ForeignKey('auth.User', null=True, blank=True)
+    user = models.ForeignKey(User, null=True, blank=True)
 
     class Meta:
         verbose_name = _('Assignment')
@@ -30,7 +35,7 @@ class OpenIDUser(models.Model):
     claimed_id = models.TextField(max_length=2047)
     email = models.EmailField()
     fullname = models.CharField(max_length=255)
-    user = models.ForeignKey('auth.User')
+    user = models.ForeignKey(User)
     last_login = models.DateTimeField(_('last login'), default=now)
 
     class Meta:


### PR DESCRIPTION
Covers the situation where your auth backend expects a Profile model.
