### PR TITLE
Follow OpenID Connect (OAuth 2.0 for Login)

### DIFF
--- a/admin_sso/tests/test_views.py
+++ b/admin_sso/tests/test_views.py
@@ -66,7 +66,7 @@ class OAuthViewTest(TestCase):
 
     def test_end_with_sucess(self):
         from admin_sso import views
-        setattr(views, 'flow_override', FlowMock({'verified_email': True, 'email': 'test@example.com'}))
+        setattr(views, 'flow_override', FlowMock({'email_verified': True, 'email': 'test@example.com'}))
         end_url = reverse('admin:admin_sso_assignment_end')
         rv = self.client.get(end_url + '?code=xxx')
         self.assertEqual(rv.status_code, 302)
@@ -77,7 +77,7 @@ class OAuthViewTest(TestCase):
 
     def test_end_with_email_not_verified(self):
         from admin_sso import views
-        setattr(views, 'flow_override', FlowMock({'verified_email': False, 'email': 'test@example.com'}))
+        setattr(views, 'flow_override', FlowMock({'email_verified': False, 'email': 'test@example.com'}))
         end_url = reverse('admin:admin_sso_assignment_end')
         rv = self.client.get(end_url + '?code=xxx')
         self.assertEqual(rv.status_code, 302)

--- a/admin_sso/views.py
+++ b/admin_sso/views.py
@@ -49,7 +49,7 @@ def end(request):
     except FlowExchangeError:
         return HttpResponseRedirect(reverse('admin:index'))
 
-    if credentials.id_token['verified_email']:
+    if credentials.id_token['email_verified']:
         email = credentials.id_token['email']
         user = authenticate(sso_email=email)
         if user and user.is_active:


### PR DESCRIPTION
Switch from `verified_email` to `email_verified`.

Deprecated early version using `verified_email`:
https://developers.google.com/accounts/docs/OAuth2LoginV1

OpenID Connect:
https://developers.google.com/accounts/docs/OpenIDConnect


(Wir wären froh um ein neues Release! Danke :-)